### PR TITLE
Remove some extraneous lorem ipsum text

### DIFF
--- a/templates/CRM/Elections/Page/ElectionCandidate.tpl
+++ b/templates/CRM/Elections/Page/ElectionCandidate.tpl
@@ -8,7 +8,6 @@
     <div class="candidate-details-right-block">
         {assign var='displayname' value='member_nominee.display_name'}
         <h2>{$nomination.$displayname}</h2>
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ut vehicula purus. Maecenas dolor arcu, facilisis et fringilla et, tempus cursus nibh. Donec eget sapien ut libero lacinia iaculis in id orci. Proin rutrum cursus velit, nec viverra leo auctor eget. Ut quis finibus nisi, in aliquet tortor. </p>
     </div><!-- ending of candidate-details-right-block -->
 </div><!-- ending of candidate-details-block -->
 


### PR DESCRIPTION
We were doing a dry run of elections and found this extraneous `lorem ipsum` text - I've removed it from linux.org.au but also raising a PR so that it doesn't catch anyone else. I wasn't sure which `member_nominee.field` should go there, so just removed the whole `<p>` element.