### PR TITLE
Check for unset values before using count

### DIFF
--- a/CRM/Elections/Page/ElectionCandidate.php
+++ b/CRM/Elections/Page/ElectionCandidate.php
@@ -76,7 +76,7 @@ class CRM_Elections_Page_ElectionCandidate extends CRM_Elections_Page_Base {
     }
 
     foreach ($positionsWithNominations as $index => $positionsWithNomination) {
-      if (count($positionsWithNomination['nominations']) == 0) {
+      if (isset($positionsWithNomination['nominations']) && count($positionsWithNomination['nominations']) == 0) {
         $positionsToRemove[] = $index;
       }
     }

--- a/templates/CRM/Elections/Page/ElectionCandidate.tpl
+++ b/templates/CRM/Elections/Page/ElectionCandidate.tpl
@@ -23,6 +23,7 @@
 
                     <h3>{$cTerm} for {$position.name}</h3>
                     {if $election->advertiseCandidatesStarted or $election->isNominationsStarted}
+                        <p>
                         {if $positionNomination.is_eligible_candidate == 1}
                             Candidate
                         {else}
@@ -42,14 +43,15 @@
                                 Pending
                             {/if}
                         {/if}
+                        </p>
                     {/if}
                 {/if}
             {/foreach}
         </div><!-- ending of candidate-details-left-block -->
 
         <div class="candidate-details-right-block">
-            <h3>Was nominated by</h3>
             {foreach from=$position.nominations item=positionNomination}
+                <h3>Was nominated by</h3>
                 {if $positionNomination.member_nominee == $nomination.member_nominee}
                     {foreach from=$positionNomination.seconders item=seconder}
                         {assign var='nominatorName' value='member_nominator.display_name'}

--- a/templates/CRM/Elections/Page/ViewElectionBlocks/nominations.tpl
+++ b/templates/CRM/Elections/Page/ViewElectionBlocks/nominations.tpl
@@ -5,7 +5,7 @@
         Existing Nominations
     {/if}
 </h2>
-{if $nominations|@count == 0 and $positions|@count == 0}
+{if !isset($nominations) or !isset($positions) or ($nominations|@count == 0 and $positions|@count == 0)}
     <p class="no-result-message">Positions are not added yet to be nominated.</p>
 {/if}
 
@@ -18,63 +18,64 @@
         {/if}
 
         <h3>{$positionKey} for {$nomination.name}</h3>
-        {if $nomination.nominations|@count == 0 and !$election->advertiseCandidatesStarted}
+
+        {if !isset($nomination.nominations) or ($nomination.nominations|@count == 0 and !$election->advertiseCandidatesStarted)}
             <p>There are no existing nominations</p>
         {/if}
         {assign var="candidatesCount" value=0}
-    <div class="election_row_style">
-        {foreach from = $nomination.nominations key = sk item = seconder}
+        <div class="election_row_style">
+            {foreach from = $nomination.nominations key = sk item = seconder}
 
-            {if (!$election->advertiseCandidatesStarted and $election->isNominationsInProgress and $seconder.has_rejected_nomination == 0) or (!$election->advertiseCandidatesStarted and !$election->isNominationsInProgress and $seconder.seconders|@count >= 2) or ($election->advertiseCandidatesStarted and !$election->isVotingStarted and $seconder.is_eligible_candidate == 1 and $seconder.has_rejected_nomination == 0) or ($election->isVotingStarted and $seconder.has_accepted_nomination == 1)}
-                {assign var='scKey' value='member_nominee.display_name'}
-                {assign var='scImgKey' value='member_nominee.image_URL'}
+                {if (!$election->advertiseCandidatesStarted and $election->isNominationsInProgress and $seconder.has_rejected_nomination == 0) or (!$election->advertiseCandidatesStarted and !$election->isNominationsInProgress and $seconder.seconders|@count >= 2) or ($election->advertiseCandidatesStarted and !$election->isVotingStarted and $seconder.is_eligible_candidate == 1 and $seconder.has_rejected_nomination == 0) or ($election->isVotingStarted and $seconder.has_accepted_nomination == 1)}
+                    {assign var='scKey' value='member_nominee.display_name'}
+                    {assign var='scImgKey' value='member_nominee.image_URL'}
 
-                <div class="crm-election-nominated-block">
-                    {if $election->isNominationsStarted}
-                        <a href="{crmURL p="civicrm/elections/candidate" q="enid=`$seconder.id`"}">
-                    {/if}
-
-                        {assign var="candidatesCount" value=$candidatesCount+1}
-                        <div class="crm-election-nominated-block inside">
-                            {assign var='profilePicUrl' value=$seconder.$scImgKey}
-                            <img src="{$profilePicUrl}" /><br><br>
-                            {$seconder.$scKey}<br>
-
-                            {if !$election->isVotingStarted and ($seconder.is_eligible_candidate == 1)}
-                                Candidate Status:
-                                {if $seconder.has_accepted_nomination == 1}
-                                    Accepted<br><br>
-                                    {$seconder.comments|nl2br}
-                                {elseif $seconder.has_rejected_nomination == 1}
-                                    Withdrawn<br><br>
-                                    {$seconder.rejection_comments|nl2br}
-                                {else}
-                                    Pending
-                                {/if}
+                    <div class="crm-election-nominated-block">
+                        {if $election->isNominationsStarted}
+                            <a href="{crmURL p="civicrm/elections/candidate" q="enid=`$seconder.id`"}">
                             {/if}
 
-                        </div>
-                    {if $election->isNominationsStarted}
-                        </a>
-                    {/if}
-                    {if $election->isNominationsInProgress and $election->required_nominations >= 2 and $seconder.seconders|@count < 2 and $seconder.is_eligible_candidate != 1}
-                        <div class="clearfix"></div>
-                        <input type="button" value="{ts}Need Second{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/nominations/create" q="eid=`$election->id`&enid=`$seconder.id`"}'" class="election-action-button" />
-                    {/if}
-                    {if $election->isNominationsInProgress and $seconder.has_rejected_nomination == 0 and $seconder.has_accepted_nomination == 0 and ($seconder.seconders|@count >= 2 or $seconder.is_eligible_candidate == 1) }
-                        <div class="clearfix"></div>
-                        <input type="button" value="{ts}Nominate{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/nominations/create" q="eid=`$election->id`&enid=`$seconder.id`"}'" class="election-action-button" />
-                    {/if}
+                            {assign var="candidatesCount" value=$candidatesCount+1}
+                            <div class="crm-election-nominated-block inside">
+                                {assign var='profilePicUrl' value=$seconder.$scImgKey}
+                                <img src="{$profilePicUrl}" /><br><br>
+                                {$seconder.$scKey}<br>
 
-                </div>
-            {/if}
+                                {if !$election->isVotingStarted and ($seconder.is_eligible_candidate == 1)}
+                                    Candidate Status:
+                                    {if $seconder.has_accepted_nomination == 1}
+                                        Accepted<br><br>
+                                        {$seconder.comments|nl2br}
+                                    {elseif $seconder.has_rejected_nomination == 1}
+                                        Withdrawn<br><br>
+                                        {$seconder.rejection_comments|nl2br}
+                                    {else}
+                                        Pending
+                                    {/if}
+                                {/if}
 
-        {/foreach}
-    </div>
-        {if $candidatesCount == 0 and $election->advertiseCandidatesStarted}
+                            </div>
+                            {if $election->isNominationsStarted}
+                            </a>
+                        {/if}
+                        {if $election->isNominationsInProgress and $election->required_nominations >= 2 and $seconder.seconders|@count < 2 and $seconder.is_eligible_candidate != 1}
+                            <div class="clearfix"></div>
+                            <input type="button" value="{ts}Need Second{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/nominations/create" q="eid=`$election->id`&enid=`$seconder.id`"}'" class="election-action-button" />
+                        {/if}
+                        {if $election->isNominationsInProgress and $seconder.has_rejected_nomination == 0 and $seconder.has_accepted_nomination == 0 and ($seconder.seconders|@count >= 2 or $seconder.is_eligible_candidate == 1) }
+                            <div class="clearfix"></div>
+                            <input type="button" value="{ts}Nominate{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/nominations/create" q="eid=`$election->id`&enid=`$seconder.id`"}'" class="election-action-button" />
+                        {/if}
+
+                    </div>
+                {/if}
+
+            {/foreach}
+        </div>
+        {if !isset($candidatesCount) or ($candidatesCount == 0 and $election->advertiseCandidatesStarted)}
             <p>There are no eligible candidates.</p>
         {/if}
-        {if $candidatesCount == 0 and !$election->advertiseCandidatesStarted and $nomination.nominations|@count != 0}
+        {if !isset($candidatesCount) or ($candidatesCount == 0 and !$election->advertiseCandidatesStarted and isset($nomination.nominations) and $nomination.nominations|@count != 0)}
             <p>There are no eligible nominations.</p>
         {/if}
     </div><div class="clearfix"></div>

--- a/templates/CRM/Elections/Page/ViewElectionBlocks/nominations.tpl
+++ b/templates/CRM/Elections/Page/ViewElectionBlocks/nominations.tpl
@@ -75,7 +75,7 @@
         {if !isset($candidatesCount) or ($candidatesCount == 0 and $election->advertiseCandidatesStarted)}
             <p>There are no eligible candidates.</p>
         {/if}
-        {if !isset($candidatesCount) or ($candidatesCount == 0 and !$election->advertiseCandidatesStarted and isset($nomination.nominations) and $nomination.nominations|@count != 0)}
+        {if !isset($candidatesCount) or !isset($nomination.nominations) or ($candidatesCount == 0 and !$election->advertiseCandidatesStarted and $nomination.nominations|@count != 0)}
             <p>There are no eligible nominations.</p>
         {/if}
     </div><div class="clearfix"></div>


### PR DESCRIPTION
This PR fixes the issue identified in #11.

In PHP 8.0.0, `count()` was changed to throw a `TypeError()` rather than a warning. (https://www.php.net/manual/en/function.count.php). This means that if the variable is unset, PHP will now throw an error.

This code change check if a variable is set before it is used with `count()`. To match existing functionality, if the variable is not set I have treated it the same as if it is set to `0`.