### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.2.6</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.45</ver>
+    <ver>5.65</ver>
   </compatibility>
   <civix>
     <namespace>CRM/Elections</namespace>

--- a/templates/CRM/Elections/Helper/Error.tpl
+++ b/templates/CRM/Elections/Helper/Error.tpl
@@ -5,5 +5,5 @@
     {/if}
 </div>
 {if $return_button_text and $return_button_action}
-    <input type="button" value="{ts}{$return_button_text}{/ts}" onclick="window.location.href='{$return_button_action}'" class="crm-form-submit default validate" />
+    <input type="button" value="{ts escape='htmlattribute'}{$return_button_text}{/ts}" onclick="window.location.href='{$return_button_action}'" class="crm-form-submit default validate" />
 {/if}

--- a/templates/CRM/Elections/Page/ElectionActions.tpl
+++ b/templates/CRM/Elections/Page/ElectionActions.tpl
@@ -5,30 +5,30 @@
                 {foreach from = $nomination.nominations key = sk item = seconder}
                         {if $seconder.is_eligible_candidate == 1 and $seconder.has_accepted_nomination == 0 and $seconder.has_rejected_nomination == 0 and $loggedInContactId == $seconder.member_nominee}
                             <div class="messages status no-popup">
-                                <span class="eligible-block">You're eligible candidate for {$nomination.name}</span> <input type="button" value="{ts}Accept Nomination{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/nominations/accept" q="enid=`$seconder.id`"}'" class="election-action-button" /> <span><input type="button" value="{ts}Withdraw nomination{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/nominations/reject" q="enid=`$seconder.id`"}'" class="election-action-button" /></span>
+                                <span class="eligible-block">You're eligible candidate for {$nomination.name}</span> <input type="button" value="{ts escape='htmlattribute'}Accept Nomination{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/nominations/accept" q="enid=`$seconder.id`"}'" class="election-action-button" /> <span><input type="button" value="{ts escape='htmlattribute'}Withdraw nomination{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/nominations/reject" q="enid=`$seconder.id`"}'" class="election-action-button" /></span>
                             </div>
                         {/if}
                         {if $seconder.is_eligible_candidate == 1 and $seconder.has_accepted_nomination == 1 and $seconder.has_rejected_nomination == 0 and $loggedInContactId == $seconder.member_nominee}
                             <div class="messages status no-popup">
-                                <span class="eligible-block">You've accepted the nomination for {$nomination.name}</span> <input type="button" value="{ts}Withdraw Nomination{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/nominations/reject" q="enid=`$seconder.id`"}'" class="election-action-button" />
+                                <span class="eligible-block">You've accepted the nomination for {$nomination.name}</span> <input type="button" value="{ts escape='htmlattribute'}Withdraw Nomination{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/nominations/reject" q="enid=`$seconder.id`"}'" class="election-action-button" />
                             </div>
                         {/if}
                         {if $election->isNominationsInProgress and $seconder.is_eligible_candidate == 0 and $seconder.has_rejected_nomination == 0 and $loggedInContactId == $seconder.member_nominee}
                             <div class="messages status no-popup">
-                                <span class="eligible-block">You're nominated for {$nomination.name}</span> <input type="button" value="{ts}Withdraw Nomination{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/nominations/reject" q="enid=`$seconder.id`"}'" class="election-action-button" />
+                                <span class="eligible-block">You're nominated for {$nomination.name}</span> <input type="button" value="{ts escape='htmlattribute'}Withdraw Nomination{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/nominations/reject" q="enid=`$seconder.id`"}'" class="election-action-button" />
                             </div>
                         {/if}
                 {/foreach}
           {/foreach}
         {/if}
         {if $election->isNominationsInProgress and $isAllowedToNominate}
-            <input type="button" value="{ts}Submit Nomination{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/nominations/create" q="eid=`$election->id`"}'" class="election-action-button" />
+            <input type="button" value="{ts escape='htmlattribute'}Submit Nomination{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/nominations/create" q="eid=`$election->id`"}'" class="election-action-button" />
         {/if}
         {if $election->isVotingStarted and !$election->isVotingEnded and $isUserAllowedToVote and $isAllowedToNominate}
-            <input type="button" value="{ts}Vote Now{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/vote" q="eid=`$election->id`"}'" class="election-action-button" />
+            <input type="button" value="{ts escape='htmlattribute'}Vote Now{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/vote" q="eid=`$election->id`"}'" class="election-action-button" />
         {/if}
         {if $election->isResultsOut}
-            <input type="button" value="{ts}Check Results{/ts}" onclick="window.location.href='{crmURL p='civicrm/elections/results' q="eid=`$election->id`"}'" class="election-action-button" />
+            <input type="button" value="{ts escape='htmlattribute'}Check Results{/ts}" onclick="window.location.href='{crmURL p='civicrm/elections/results' q="eid=`$election->id`"}'" class="election-action-button" />
         {/if}
     </div>
 {/if}

--- a/templates/CRM/Elections/Page/ViewElectionBlocks/nominations.tpl
+++ b/templates/CRM/Elections/Page/ViewElectionBlocks/nominations.tpl
@@ -60,11 +60,11 @@
                         {/if}
                         {if $election->isNominationsInProgress and $election->required_nominations >= 2 and $seconder.seconders|@count < 2 and $seconder.is_eligible_candidate != 1}
                             <div class="clearfix"></div>
-                            <input type="button" value="{ts}Need Second{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/nominations/create" q="eid=`$election->id`&enid=`$seconder.id`"}'" class="election-action-button" />
+                            <input type="button" value="{ts escape='htmlattribute'}Need Second{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/nominations/create" q="eid=`$election->id`&enid=`$seconder.id`"}'" class="election-action-button" />
                         {/if}
                         {if $election->isNominationsInProgress and $seconder.has_rejected_nomination == 0 and $seconder.has_accepted_nomination == 0 and ($seconder.seconders|@count >= 2 or $seconder.is_eligible_candidate == 1) }
                             <div class="clearfix"></div>
-                            <input type="button" value="{ts}Nominate{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/nominations/create" q="eid=`$election->id`&enid=`$seconder.id`"}'" class="election-action-button" />
+                            <input type="button" value="{ts escape='htmlattribute'}Nominate{/ts}" onclick="window.location.href='{crmURL p="civicrm/elections/nominations/create" q="eid=`$election->id`&enid=`$seconder.id`"}'" class="election-action-button" />
                         {/if}
 
                     </div>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.