### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Elections/Form/AcceptNomination.php
+++ b/CRM/Elections/Form/AcceptNomination.php
@@ -28,7 +28,7 @@ class CRM_Elections_Form_AcceptNomination extends CRM_Elections_Form_Base {
         'is_eligible_candidate' => 1,
         'return' => ['has_accepted_nomination', 'election_position_id.name', 'has_rejected_nomination', 'election_position_id.election_id.name', 'election_position_id.election_id'],
       ]);
-    } catch (CiviCRM_API3_Exception $e) {
+    } catch (CRM_Core_Exception $e) {
       throwAccessDeniedException($this, $e->getMessage());
       return;
     }

--- a/CRM/Elections/Form/CreateElection.php
+++ b/CRM/Elections/Form/CreateElection.php
@@ -181,7 +181,7 @@ class CRM_Elections_Form_CreateElection extends CRM_Elections_Form_Base {
         return;
       }
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       CRM_Core_Session::setStatus($e->getMessage(), '', 'error');
       return;
     }

--- a/CRM/Elections/Form/CreateElectionNomination.php
+++ b/CRM/Elections/Form/CreateElectionNomination.php
@@ -60,7 +60,7 @@ class CRM_Elections_Form_CreateElectionNomination extends CRM_Elections_Form_Bas
           'election_position_id.election_id' => $this->eId,
         ]);
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         return FALSE;
       }
     }
@@ -125,7 +125,7 @@ class CRM_Elections_Form_CreateElectionNomination extends CRM_Elections_Form_Bas
    * @param $values
    * @return array|int
    * @throws CRM_Extension_Exception
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    */
   private function getNominationId($values) {
     $nominationId = 0;
@@ -226,7 +226,7 @@ class CRM_Elections_Form_CreateElectionNomination extends CRM_Elections_Form_Bas
    *
    * @param $nominationId
    * @return bool
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    */
   private function markNominationAsEligibleCandidate($nominationId) {
     $totalNominations = civicrm_api3('ElectionNominationSeconder', 'getcount', [

--- a/CRM/Elections/Form/RejectNomination.php
+++ b/CRM/Elections/Form/RejectNomination.php
@@ -28,7 +28,7 @@ class CRM_Elections_Form_RejectNomination extends CRM_Elections_Form_Base {
         'return' => ['has_accepted_nomination', 'is_eligible_candidate', 'election_position_id.name', 'election_position_id.election_id.name', 'has_rejected_nomination', 'election_position_id.election_id'],
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       throwAccessDeniedException($this, $e->getMessage());
       return;
     }

--- a/CRM/Elections/Page/ElectionCandidate.php
+++ b/CRM/Elections/Page/ElectionCandidate.php
@@ -24,7 +24,7 @@ class CRM_Elections_Page_ElectionCandidate extends CRM_Elections_Page_Base {
         'return' => ['has_accepted_nomination', 'comments', 'election_position_id.name', 'election_position_id.election_id.name', 'election_position_id.election_id', 'member_nominee', 'member_nominee.display_name', 'member_nominee.image_URL'],
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       throwAccessDeniedException($this, $e->getMessage());
       parent::run();
       return;

--- a/Civi/Elections/FormProcessor/NominationType.php
+++ b/Civi/Elections/FormProcessor/NominationType.php
@@ -97,7 +97,7 @@ class NominationType extends AbstractType implements OptionListInterface {
           'id' => $nomination['member_nominee'],
           'return' => 'display_name'
         ]);
-      } catch (\CiviCRM_API3_Exception $ex) {
+      } catch (\CRM_Core_Exception $ex) {
         // Do nothing.
       }
       $nominations[$nomination['id']] = $display_name;

--- a/api/v3/Election.php
+++ b/api/v3/Election.php
@@ -26,7 +26,7 @@ function _civicrm_api3_election_create_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_create($params) {
   $apiDateFormat = 'YmdHis';
@@ -57,7 +57,7 @@ function civicrm_api3_election_create($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -68,7 +68,7 @@ function civicrm_api3_election_delete($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -79,7 +79,7 @@ function civicrm_api3_election_get($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_generateresults($params) {
   $currentDateTime = new DateTime();

--- a/api/v3/ElectionNomination.php
+++ b/api/v3/ElectionNomination.php
@@ -19,7 +19,7 @@ function _civicrm_api3_election_nomination_create_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_nomination_create($params) {
   if (!isset($params['id'])) {
@@ -58,7 +58,7 @@ function civicrm_api3_election_nomination_create($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_nomination_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -69,7 +69,7 @@ function civicrm_api3_election_nomination_delete($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_nomination_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);

--- a/api/v3/ElectionNominationSeconder.php
+++ b/api/v3/ElectionNominationSeconder.php
@@ -19,7 +19,7 @@ function _civicrm_api3_election_nomination_seconder_create_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_nomination_seconder_create($params) {
   if (!isset($params['id'])) {
@@ -59,7 +59,7 @@ function civicrm_api3_election_nomination_seconder_create($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_nomination_seconder_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -70,7 +70,7 @@ function civicrm_api3_election_nomination_seconder_delete($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_nomination_seconder_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);

--- a/api/v3/ElectionNominee/Getlist.php
+++ b/api/v3/ElectionNominee/Getlist.php
@@ -34,7 +34,7 @@ function _civicrm_api3_election_nominee_Getlist_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_nominee_Getlist($params) {
   $electionId = $params['election_id'];

--- a/api/v3/ElectionPosition.php
+++ b/api/v3/ElectionPosition.php
@@ -20,7 +20,7 @@ function _civicrm_api3_election_position_create_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_position_create($params) {
   $electionId = $params['election_id'];
@@ -41,7 +41,7 @@ function civicrm_api3_election_position_create($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_position_delete($params) {
   $electionPosition = civicrm_api3_election_position_get($params);
@@ -60,7 +60,7 @@ function civicrm_api3_election_position_delete($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_position_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);

--- a/api/v3/ElectionResult.php
+++ b/api/v3/ElectionResult.php
@@ -20,7 +20,7 @@ function _civicrm_api3_election_result_create_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_result_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -31,7 +31,7 @@ function civicrm_api3_election_result_create($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_result_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -42,7 +42,7 @@ function civicrm_api3_election_result_delete($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_result_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);

--- a/api/v3/ElectionVote.php
+++ b/api/v3/ElectionVote.php
@@ -58,7 +58,7 @@ function _civicrm_api3_election_vote_addvotes_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_vote_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -69,7 +69,7 @@ function civicrm_api3_election_vote_create($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_vote_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -79,7 +79,7 @@ function civicrm_api3_election_vote_delete($params) {
  * ElectionVote.deletevotes API
  *
  * @param array $params
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_vote_deletevotes($params) {
   $electionId = $params['election_id'];
@@ -104,7 +104,7 @@ function civicrm_api3_election_vote_deletevotes($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_vote_addvotes($params) {
   $electionId = $params['election_id'];
@@ -158,7 +158,7 @@ function civicrm_api3_election_vote_addvotes($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_election_vote_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);

--- a/elections.php
+++ b/elections.php
@@ -190,7 +190,7 @@ function elections_civicrm_coreResourceList(&$list, $region) {
  * Check if logged in user is member of any election admin group.
  *
  * @return bool
- * @throws CiviCRM_API3_Exception
+ * @throws CRM_Core_Exception
  */
 function isElectionAdmin() {
   return CRM_Core_Permission::check('administer Elections');
@@ -200,7 +200,7 @@ function isElectionAdmin() {
  * Throw unauthorized message if logged in contact is not allowed to perform certain actions.
  *
  * @throws CRM_Extension_Exception
- * @throws CiviCRM_API3_Exception
+ * @throws CRM_Core_Exception
  */
 function throwUnauthorizedMessageIfRequired($formOrPage) {
   if (!isElectionAdmin()) {
@@ -349,7 +349,7 @@ function elections_civicrm_managed(&$entities) {
  * Check if logged in member has current membership return if he/she is allowed to vote/nominate in election.
  *
  * @return bool
- * @throws CiviCRM_API3_Exception
+ * @throws CRM_Core_Exception
  */
 function isLoggedInMemberAllowedToVote($electionId, $contactId = NULL) {
   if ($contactId == NULL) {
@@ -401,7 +401,7 @@ function isMemberAllowedToReVote($electionId) {
  *
  * @param $electionId
  * @return bool
- * @throws CiviCRM_API3_Exception
+ * @throws CRM_Core_Exception
  */
 function hasLoggedInUserAlreadyVoted($electionId, $memberId = NULL) {
   if (!$memberId) {
@@ -421,7 +421,7 @@ function hasLoggedInUserAlreadyVoted($electionId, $memberId = NULL) {
  *
  * @param $electionId
  * @return bool
- * @throws CiviCRM_API3_Exception
+ * @throws CRM_Core_Exception
  */
 function getLoggedInUserVoteDate($electionId) {
   $voteDate = civicrm_api3('ElectionVote', 'get', [

--- a/tests/phpunit/api/v3/ElectionBaseTestCase.php
+++ b/tests/phpunit/api/v3/ElectionBaseTestCase.php
@@ -227,7 +227,7 @@ class api_v3_ElectionBaseTestCase extends CiviCaseTestCase implements HeadlessIn
    * Create successful nomination.
    *
    * @return array
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    */
   public function createNomination($params = []) {
     $nominee = $this->individualCreate();

--- a/tests/phpunit/api/v3/ElectionNominationSeconderTest.php
+++ b/tests/phpunit/api/v3/ElectionNominationSeconderTest.php
@@ -114,7 +114,7 @@ class api_v3_ElectionNominationSeconderTest extends api_v3_ElectionBaseTestCase 
    * Create nomination seconder.
    *
    * @return array
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    */
   private function createNominationSeconder() {
     $nominator = $this->individualCreate();


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.