### PR TITLE
Remove commented-out boilerplate

### DIFF
--- a/CRM/Elections/BAO/ElectionNomination.php
+++ b/CRM/Elections/BAO/ElectionNomination.php
@@ -3,24 +3,5 @@ use CRM_Elections_ExtensionUtil as E;
 
 class CRM_Elections_BAO_ElectionNomination extends CRM_Elections_DAO_ElectionNomination {
 
-  /**
-   * Create a new ElectionNomination based on array-data
-   *
-   * @param array $params key-value pairs
-   * @return CRM_Elections_DAO_ElectionNomination|NULL
-   *
-  public static function create($params) {
-    $className = 'CRM_Elections_DAO_ElectionNomination';
-    $entityName = 'ElectionNomination';
-    $hook = empty($params['id']) ? 'create' : 'edit';
-
-    CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
-    $instance = new $className();
-    $instance->copyValues($params);
-    $instance->save();
-    CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
-
-    return $instance;
-  } */
 
 }

--- a/CRM/Elections/BAO/ElectionNominationSeconder.php
+++ b/CRM/Elections/BAO/ElectionNominationSeconder.php
@@ -3,24 +3,5 @@ use CRM_Elections_ExtensionUtil as E;
 
 class CRM_Elections_BAO_ElectionNominationSeconder extends CRM_Elections_DAO_ElectionNominationSeconder {
 
-  /**
-   * Create a new ElectionNominationSeconder based on array-data
-   *
-   * @param array $params key-value pairs
-   * @return CRM_Elections_DAO_ElectionNominationSeconder|NULL
-   *
-  public static function create($params) {
-    $className = 'CRM_Elections_DAO_ElectionNominationSeconder';
-    $entityName = 'ElectionNominationSeconder';
-    $hook = empty($params['id']) ? 'create' : 'edit';
-
-    CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
-    $instance = new $className();
-    $instance->copyValues($params);
-    $instance->save();
-    CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
-
-    return $instance;
-  } */
 
 }

--- a/CRM/Elections/BAO/ElectionVote.php
+++ b/CRM/Elections/BAO/ElectionVote.php
@@ -3,24 +3,5 @@ use CRM_Elections_ExtensionUtil as E;
 
 class CRM_Elections_BAO_ElectionVote extends CRM_Elections_DAO_ElectionVote {
 
-  /**
-   * Create a new ElectionVote based on array-data
-   *
-   * @param array $params key-value pairs
-   * @return CRM_Elections_DAO_ElectionVote|NULL
-   *
-  public static function create($params) {
-    $className = 'CRM_Elections_DAO_ElectionVote';
-    $entityName = 'ElectionVote';
-    $hook = empty($params['id']) ? 'create' : 'edit';
-
-    CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
-    $instance = new $className();
-    $instance->copyValues($params);
-    $instance->save();
-    CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
-
-    return $instance;
-  } */
 
 }


### PR DESCRIPTION
Civix used to generate commented-out BAO create functions, however all BAOs now inherit writeRecords() from their parent.

Since this function was never uncommented, it's safe to remove.