### PR TITLE
fix case for view elections permission

### DIFF
--- a/CRM/Elections/Permission.php
+++ b/CRM/Elections/Permission.php
@@ -6,7 +6,7 @@ class CRM_Elections_Permission {
    * Custom access callback function specified in xml/Menu/Elections.xml.
    *
    * This function implements the core logic:
-   * 1. Checks if the current user has the 'view elections' permission.
+   * 1. Checks if the current user has the 'view Elections' permission.
    * 2. If not, it checks for a valid contact ID (cid) and checksum (cs) in the URL.
    *
    * @return bool
@@ -15,7 +15,7 @@ class CRM_Elections_Permission {
   public static function check() {
     // Check for the explicit CiviCRM permission first.
     // Always grant access to logged-in users with the right role.
-    if (CRM_Core_Permission::check('view elections')) {
+    if (CRM_Core_Permission::check('view Elections')) {
       return TRUE;
     }
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -27,7 +27,7 @@ If this Scheduled Job is not enabled or executed, then no election results will 
 1. In CiviCRM, on the WordPress Access Control page,  _/wp-admin/admin.php?page=CiviCRM&q=civicrm%2Fadmin%2Faccess%2Fwp-permissions&reset=1_
 2. Enable these two additional permissions for the **User Roles** that need to _participate in the election_
 -  **CiviCRM: access AJAX API**
--  **CiviCRM: view elections**
+-  **CiviCRM: view Elections**
 
 Other default permissions which should already be enabled for the **User Role** role to interact with CiviCRM and will also be required are listed below.
 -  **CiviCRM: access uploaded files**

--- a/elections.php
+++ b/elections.php
@@ -479,7 +479,7 @@ function elections_civicrm_permission(&$permissions) {
     'description' => E::ts('Grants the necessary permissions for administrating elections in CiviCRM.'),
   ];
   $permissions['view Elections'] = [
-    'label' => E::ts('CiviCRM: view elections'),
+    'label' => E::ts('CiviCRM: view Elections'),
     'description' => E::ts('Grants the necessary permissions for participating in elections.'),
   ];
 }
@@ -532,7 +532,7 @@ function elections_civicrm_alterAPIPermissions($entity, $action, &$params, &$per
   $referer_parsed = parse_url($referer);
   parse_str($referer_parsed['query'], $query_params);
 
-  // Bypass 'view elections' permissions if we have a validated checksum.
+  // Bypass 'view Elections' permissions if we have a validated checksum.
   // Defer to AJAX API permissions.
   if ( $query_params['cid'] && $query_params['cs'] ) {
     $results = \Civi\Api4\Contact::validateChecksum(FALSE)


### PR DESCRIPTION
Permissions are case sensitive - this PR ensures the permission to view elections is consistently spelled: "view Elections" (instead of "view elections").